### PR TITLE
🐛 notify url not needed in production

### DIFF
--- a/config/generateProdConfig.js
+++ b/config/generateProdConfig.js
@@ -34,7 +34,6 @@ module.exports = () => ({
     end: process.env.MAINTENANCE_END,
   },
   notify: {
-    url: envOrThrow('NOTIFY_URL'),
     clientKey: envOrThrow('NOTIFY_CLIENT_KEY'),
     smsTemplateId: envOrThrow('NOTIFY_SMS_TEMPLATE'),
     emailTemplateId: envOrThrow('NOTIFY_EMAIL_TEMPLATE'),


### PR DESCRIPTION
- remove notify url property for production config