### PR TITLE
🏗 Setup notifications service with integration tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ package-lock.json
 package.json
 cypress.json
 cypress-reporter-config.json
+jest.config.json
+jest.config.integration.json

--- a/config.js
+++ b/config.js
@@ -55,6 +55,9 @@ module.exports = {
     emailTemplateId: get('NOTIFY_EMAIL_TEMPLATE', 'not_email', requiredInProduction),
     healthCheckUrl: process.env.NOTIFY_HEALTH_CHECK_URL || 'https://api.notifications.service.gov.uk/_status',
   },
+  notifcationService: {
+    url: get('NOTIFICATION_SERVICE_URL', 'http://localhost:9191/notifications-service'),
+  },
   hmppsCookie: {
     name: process.env.HMPPS_COOKIE_NAME || 'hmpps-session-dev',
     domain: process.env.HMPPS_COOKIE_DOMAIN || 'localhost',

--- a/config.js
+++ b/config.js
@@ -55,8 +55,8 @@ module.exports = {
     emailTemplateId: get('NOTIFY_EMAIL_TEMPLATE', 'not_email', requiredInProduction),
     healthCheckUrl: process.env.NOTIFY_HEALTH_CHECK_URL || 'https://api.notifications.service.gov.uk/_status',
   },
-  notifcationService: {
-    url: get('NOTIFICATION_SERVICE_URL', 'http://localhost:9191/notifications-service'),
+  cmdApi: {
+    url: get('CMD_API_URL', 'http://localhost:9191'),
   },
   hmppsCookie: {
     name: process.env.HMPPS_COOKIE_NAME || 'hmpps-session-dev',

--- a/integration-tests/mockApis/notificationService.js
+++ b/integration-tests/mockApis/notificationService.js
@@ -1,0 +1,20 @@
+const { stubFor } = require('./wiremock')
+
+const stubNotificationService = async () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/notifications-service',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      jsonBody: {
+        testEndpoint: true,
+      },
+    },
+  })
+
+module.exports = stubNotificationService

--- a/integration-tests/mockApis/notificationService.js
+++ b/integration-tests/mockApis/notificationService.js
@@ -1,10 +1,10 @@
 const { stubFor } = require('./wiremock')
 
-const stubNotificationService = async () =>
+const stubNotificationGet = async () =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: '/notifications-service',
+      urlPattern: '/preferences/notifications',
     },
     response: {
       status: 200,
@@ -12,9 +12,26 @@ const stubNotificationService = async () =>
         'Content-Type': 'application/json',
       },
       jsonBody: {
-        testEndpoint: true,
+        snoozeUntil: '2020-08-27',
       },
     },
   })
 
-module.exports = stubNotificationService
+const stubNotificationUpdate = async () =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      urlPattern: '/preferences/notifications/snooze',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  })
+
+module.exports = {
+  stubNotificationGet,
+  stubNotificationUpdate,
+}

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -2,6 +2,7 @@ const auth = require('../mockApis/auth')
 const { resetStubs } = require('../mockApis/wiremock')
 const { stubTasks, stubShifts, stubOvertimeShifts, stubHealthCalls } = require('../mockApis/prisonOfficerApi')
 const { clearDb, createTablesInsertData } = require('../db/db')
+const { stubNotificationService } = require('../mockApis/notificationService')
 
 module.exports = (on) => {
   on('task', {
@@ -14,6 +15,7 @@ module.exports = (on) => {
     stubShifts,
     stubOvertimeShifts,
     stubHealthCalls,
+    stubNotificationService,
 
     createTablesInsertData,
   })

--- a/integration-tests/wiremock-tests/notifcation-service.test.js
+++ b/integration-tests/wiremock-tests/notifcation-service.test.js
@@ -1,0 +1,22 @@
+const stubNotificationService = require('../mockApis/notificationService')
+const { resetStubs } = require('../mockApis/wiremock')
+const config = require('../../config')
+const notifcationService = require('../../server/services/notificationService')
+
+describe('Wiremock setup for notification service', () => {
+  beforeAll(async () => {
+    await resetStubs()
+    await stubNotificationService()
+  })
+
+  test('Notifcation service is stubbed', async () => {
+    try {
+      expect(config.notifcationService.url).toEqual('http://localhost:9191/notifications-service')
+      const response = await notifcationService().get(config.notifcationService.url)
+      expect(response.status).toBe(200)
+      expect(response.data).toEqual({ testEndpoint: true })
+    } catch (error) {
+      expect(error).toBeFalsy()
+    }
+  })
+})

--- a/integration-tests/wiremock-tests/notifcation-service.test.js
+++ b/integration-tests/wiremock-tests/notifcation-service.test.js
@@ -1,20 +1,28 @@
-const stubNotificationService = require('../mockApis/notificationService')
+const {stubNotificationGet, stubNotificationUpdate} = require('../mockApis/notificationService')
 const { resetStubs } = require('../mockApis/wiremock')
-const config = require('../../config')
 const notifcationService = require('../../server/services/notificationService')
 
 describe('Wiremock setup for notification service', () => {
   beforeAll(async () => {
     await resetStubs()
-    await stubNotificationService()
+    await stubNotificationGet()
+    await stubNotificationUpdate()
   })
 
-  test('Notifcation service is stubbed', async () => {
+  test('notifcationService.get is stubbed', async () => {
     try {
-      expect(config.notifcationService.url).toEqual('http://localhost:9191/notifications-service')
-      const response = await notifcationService().get(config.notifcationService.url)
+      const response = await notifcationService.get()
       expect(response.status).toBe(200)
-      expect(response.data).toEqual({ testEndpoint: true })
+      expect(response.data).toEqual({ snoozeUntil: "2020-08-27" })
+    } catch (error) {
+      expect(error).toBeFalsy()
+    }
+  })
+
+  test('notifcationService.updateSnooze is stubbed', async () => {
+    try {
+      const response = await notifcationService.updateSnooze()
+      expect(response.status).toBe(200)
     } catch (error) {
       expect(error).toBeFalsy()
     }

--- a/jest.config.integration.json
+++ b/jest.config.integration.json
@@ -1,0 +1,23 @@
+{
+  "testMatch": [
+    "<rootDir>/integration-tests/wiremock-tests/**/?.test.{ts,js,jsx,mjs}",
+    "<rootDir>/integration-tests/wiremock-tests/**/*.test.{js,jsx,ts,tsx}",
+    "<rootDir>/integration-tests/wiremock-tests/**/?.test.{js,jsx,ts,tsx}"
+  ],
+  "testEnvironment": "node",
+  "reporters": [
+    "default",
+    [
+      "jest-junit",
+      {
+        "outputDirectory": "test-results/jest/"
+      }
+    ],
+    [
+      "./node_modules/jest-html-reporter",
+      {
+        "outputPath": "test-results/integration-test-reports.html"
+      }
+    ]
+  ]
+}

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,23 @@
+{
+  "testMatch": [
+    "<rootDir>/server/**/?(*.)(spec|test).{ts,js,jsx,mjs}",
+    "<rootDir>/server/**/*.(test).{js,jsx,ts,tsx}",
+    "<rootDir>/server/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
+  ],
+  "testEnvironment": "node",
+  "reporters": [
+    "default",
+    [
+      "jest-junit",
+      {
+        "outputDirectory": "test-results/jest/"
+      }
+    ],
+    [
+      "./node_modules/jest-html-reporter",
+      {
+        "outputPath": "test-results/unit-test-reports.html"
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "css-build": "./bin/build-css",
     "clean": "rm -rf assets/* .port.tmp *.log build/* uploads/* test-results.xml",
     "lint": "eslint . --cache --max-warnings 0",
-    "test": "jest",
+    "test": "jest --config=jest.config.json",
     "int-test": "cypress run",
     "int-test-ui": "cypress open",
     "migrate": "knex migrate:latest",
     "record-build-info": "node ./bin/record-build-info",
-    "security_audit": "npx audit-ci --config audit-ci.json"
+    "security_audit": "npx audit-ci --config audit-ci.json",
+    "test-mocks": "jest --config=jest.config.integration.json"
   },
   "engines": {
     "node": ">=10.15.3",
@@ -89,29 +90,6 @@
     "nock": "^10.0.6",
     "prettier": "^2.0.2",
     "supertest": "^3.4.2"
-  },
-  "jest": {
-    "testMatch": [
-      "<rootDir>/server/**/?(*.)(spec|test).{ts,js,jsx,mjs}",
-      "<rootDir>/server/**/*.(test).{js,jsx,ts,tsx}",
-      "<rootDir>/server/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
-    ],
-    "testEnvironment": "node",
-    "reporters": [
-      "default",
-      [
-        "jest-junit",
-        {
-          "outputDirectory": "test-results/jest/"
-        }
-      ],
-      [
-        "./node_modules/jest-html-reporter",
-        {
-          "outputPath": "test-results/unit-test-reports.html"
-        }
-      ]
-    ]
   },
   "husky": {
     "hooks": {

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -1,10 +1,11 @@
 const axios = require('axios')
 const logger = require('../../log')
+const baseUrl = require('../../config').cmdApi.url
 
-module.exports = function notificationService() {
-  function get(notificationServiceUrl, accessToken) {
+module.exports = {
+  get(accessToken) {
     return axios
-      .get(`${notificationServiceUrl}`, {
+      .get(`${baseUrl}/preferences/notifications`, {
         headers: {
           authorization: `Bearer ${accessToken}`,
         },
@@ -13,9 +14,19 @@ module.exports = function notificationService() {
         logger.error(`notificationService : ${error}`)
         return error
       })
-  }
+  },
 
-  return {
-    get,
-  }
+  updateSnooze(accessToken, snoozeUntil) {
+    return axios
+      .put(`${baseUrl}/preferences/notifications/snooze`, {
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        data: { snoozeUntil },
+      })
+      .catch((error) => {
+        logger.error(`notificationService : ${error}`)
+        return error
+      })
+  },
 }

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -1,0 +1,21 @@
+const axios = require('axios')
+const logger = require('../../log')
+
+module.exports = function notificationService() {
+  function get(notificationServiceUrl, accessToken) {
+    return axios
+      .get(`${notificationServiceUrl}`, {
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .catch((error) => {
+        logger.error(`notificationService : ${error}`)
+        return error
+      })
+  }
+
+  return {
+    get,
+  }
+}


### PR DESCRIPTION
**Changes:**
- create skeleton for notifications service
- setup jest to run integrations tests
- setup wiremock for notifications service with dummy test