### PR TITLE
Revert "DT-974: Add additional mfa roles"

### DIFF
--- a/server/helpers/utilities.js
+++ b/server/helpers/utilities.js
@@ -128,16 +128,7 @@ function processOvertimeShifts(shiftsData, overtimeShiftsData) {
   return shiftsData
 }
 
-const hmppsAuthMFAUser = (token) => {
-  const {authorities} = jwtDecode(token)
-  return (
-    authorities.includes('ROLE_MFA') ||
-    authorities.includes('ROLE_MAINTAIN_ACCESS_ROLES') ||
-    authorities.includes('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN') ||
-    authorities.includes('ROLE_MAINTAIN_OAUTH_USERS') ||
-    authorities.includes('ROLE_AUTH_GROUP_MANAGER')
-  )
-}
+const hmppsAuthMFAUser = (token) => jwtDecode(token).authorities.includes('ROLE_MFA')
 
 module.exports = {
   getStartMonth,

--- a/server/helpers/utilities.test.js
+++ b/server/helpers/utilities.test.js
@@ -8,27 +8,11 @@ describe('hmppsAuthMFAUser', () => {
     jest.resetAllMocks()
   })
   it('should return true if the user has the ROLE_MFA role', () => {
-    const token = { authorities: ['ROLE_PRISON', 'ROLE_MFA'] }
+    const token = { authorities: 'ROLE_MFA' }
     expect(hmppsAuthMFAUser(token)).toEqual(true)
   })
-  it('should return true if the user has the ROLE_MAINTAIN_ACCESS_ROLES role', () => {
-    const token = { authorities: ['ROLE_PRISON', 'ROLE_MAINTAIN_ACCESS_ROLES'] }
-    expect(hmppsAuthMFAUser(token)).toEqual(true)
-  })
-  it('should return true if the user has the ROLE_MAINTAIN_ACCESS_ROLES_ADMIN role', () => {
-    const token = { authorities: ['ROLE_PRISON', 'ROLE_MAINTAIN_ACCESS_ROLES_ADMIN'] }
-    expect(hmppsAuthMFAUser(token)).toEqual(true)
-  })
-  it('should return true if the user has the ROLE_MAINTAIN_OAUTH_USERS role', () => {
-    const token = { authorities: ['ROLE_PRISON', 'ROLE_MAINTAIN_OAUTH_USERS'] }
-    expect(hmppsAuthMFAUser(token)).toEqual(true)
-  })
-  it('should return true if the user has the ROLE_AUTH_GROUP_MANAGER role', () => {
-    const token = { authorities: ['ROLE_PRISON', 'ROLE_AUTH_GROUP_MANAGER'] }
-    expect(hmppsAuthMFAUser(token)).toEqual(true)
-  })
-  it('should return false if the user does not have an mfa role', () => {
-    const token = { authorities: ['ROLE_PRISON'] }
+  it('should return false if the user does not have the ROLE_MFA role', () => {
+    const token = { authorities: '' }
     expect(hmppsAuthMFAUser(token)).toEqual(false)
   })
 })


### PR DESCRIPTION
Reverts ministryofjustice/check-my-diary#108.

Turns out that there are 237 check my diary users who would be affected by this change so will have to plan for it in the future.