### PR TITLE
Remove slow call

### DIFF
--- a/integration-tests/wiremock-tests/notifcation-service.test.js
+++ b/integration-tests/wiremock-tests/notifcation-service.test.js
@@ -6,28 +6,6 @@ const {
 const { resetStubs } = require('../mockApis/wiremock')
 const notifciationService = require('../../server/services/notificationService')
 
-const fakeShiftNotifications = [
-  {
-    description: 'Your activity on Wednesday 29 May 2019 at 17:00 - 17:30 has changed to [Paternity Leave].',
-    shiftModified: '2019-05-29T13:53:01.000Z',
-    processed: true,
-  },
-  {
-    description: 'Your activity on Wednesday 29 May 2019 at 15:00 - 17:00 has changed to [FMI Training].',
-    shiftModified: '2019-05-29T13:46:19.000Z',
-    processed: true,
-  },
-  {
-    description: 'Your activity on Wednesday 29 May 2019 at 17:00 - 17:30 has changed to [Late Roll (OSG)].',
-    shiftModified: '2019-05-29T13:43:37.000Z',
-    processed: true,
-  },
-  {
-    description: 'Your activity on Wednesday 29 May 2019 at 15:00 - 17:00 has changed to [FMI Training].',
-    shiftModified: '2019-05-29T13:36:43.000Z',
-    processed: true,
-  },
-]
 
 describe('Wiremock setup for notification service', () => {
   beforeAll(async () => {
@@ -35,16 +13,6 @@ describe('Wiremock setup for notification service', () => {
     await stubNotificationCount()
     await stubNotificationPreferencesGet()
     await stubNotificationUpdate()
-  })
-
-  test('notificationService.count is stubbed', async () => {
-    try {
-      const response = await notifciationService.countUnprocessedNotifications()
-      expect(response.status).toBe(200)
-      expect(response.data).toEqual(fakeShiftNotifications)
-    } catch (error) {
-      expect(error).toBeFalsy()
-    }
   })
 
   test('notificationService.getPreference is stubbed', async () => {

--- a/server/middleware/calendarMiddleware.js
+++ b/server/middleware/calendarMiddleware.js
@@ -13,10 +13,10 @@ const calendarMiddleware = async (req, res, next) => {
     authUrl,
   } = req
 
-  const { calendarService, notificationService } = app.get('DataServices')
+  const { calendarService } = app.get('DataServices')
 
   try {
-    const notificationCount = await notificationService.countUnprocessedNotifications(token)
+    const notificationCount = 0
 
     const month = await calendarService.getCalendarMonth(date, token)
     month.forEach(processDay)

--- a/server/middleware/calendarMiddleware.js
+++ b/server/middleware/calendarMiddleware.js
@@ -16,7 +16,6 @@ const calendarMiddleware = async (req, res, next) => {
   const { calendarService } = app.get('DataServices')
 
   try {
-    const notificationCount = 0
 
     const month = await calendarService.getCalendarMonth(date, token)
     month.forEach(processDay)
@@ -26,7 +25,6 @@ const calendarMiddleware = async (req, res, next) => {
     const nextMonthMoment = currentMonthMoment.clone().add('1', 'M')
     return res.render('pages/calendar', {
       ...res.locals,
-      notificationCount,
       tab: 'Calendar',
       currentMonth: currentMonthMoment.format('MMMM YYYY'),
       previousMonth: { link: previousMonthMoment.format('YYYY-MM-DD'), text: previousMonthMoment.format('MMMM') },

--- a/server/middleware/calendarMiddleware.test.js
+++ b/server/middleware/calendarMiddleware.test.js
@@ -25,7 +25,6 @@ describe('calendar middleware', () => {
   let res
   const calendarData = ['sausages']
   const returnCalendarData = ['bacon']
-  const notificationCount = 42
   beforeEach(async () => {
     configureCalendar.mockReturnValue(returnCalendarData)
     getCalendarMonthMock.mockResolvedValue(calendarData)

--- a/server/middleware/calendarMiddleware.test.js
+++ b/server/middleware/calendarMiddleware.test.js
@@ -16,11 +16,9 @@ describe('calendar middleware', () => {
   const authUrl = ''
   const csrfToken = 'tomato'
   const getCalendarMonthMock = jest.fn()
-  const countUnprocessedNotificationsMock = jest.fn()
   const app = {
     get: () => ({
       calendarService: { getCalendarMonth: getCalendarMonthMock },
-      notificationService: { countUnprocessedNotifications: countUnprocessedNotificationsMock },
     }),
   }
   let req
@@ -31,7 +29,6 @@ describe('calendar middleware', () => {
   beforeEach(async () => {
     configureCalendar.mockReturnValue(returnCalendarData)
     getCalendarMonthMock.mockResolvedValue(calendarData)
-    countUnprocessedNotificationsMock.mockResolvedValue(notificationCount)
     res = { render: renderMock, locals: { csrfToken } }
     req = {
       hmppsAuthMFAUser,
@@ -47,9 +44,6 @@ describe('calendar middleware', () => {
     jest.resetAllMocks()
   })
   describe('with valid data', () => {
-    it('should get the notification count', () => {
-      expect(countUnprocessedNotificationsMock).toHaveBeenCalledTimes(1)
-    })
     it('should get calendar data', () => {
       expect(getCalendarMonthMock).toHaveBeenCalledTimes(1)
     })

--- a/server/services/healthcheck.js
+++ b/server/services/healthcheck.js
@@ -1,19 +1,12 @@
-const { dbCheck, serviceCheckFactory } = require('../data/healthcheck')
+const { dbCheck } = require('../data/healthcheck')
 
 const db = () =>
   dbCheck()
     .then(() => ({ name: 'db', status: 'ok', message: 'OK' }))
     .catch((err) => ({ name: 'db', status: 'ERROR', message: err.message }))
 
-const service = (name, url) => {
-  const check = serviceCheckFactory(name, url)
-  return () =>
-    check()
-      .then((result) => ({ name, status: 'ok', message: result }))
-      .catch((err) => ({ name, status: 'ERROR', message: err }))
-}
 
-module.exports = function healthcheckFactory(authUrl) {
+module.exports = function healthcheckFactory() {
   const checks = [db]
 
   return (callback) =>

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -19,11 +19,6 @@ const notificationService = {
       })
   },
 
-  async countUnprocessedNotifications(accessToken) {
-    const data = await notificationService.getNotifications(accessToken, false, true)
-    return data.length
-  },
-
   getPreferences(accessToken) {
     return axios
       .get(`${baseUrl}/preferences/notifications`, {

--- a/server/views/pages/calendar.ejs
+++ b/server/views/pages/calendar.ejs
@@ -18,11 +18,6 @@
             <li>
               <a href="/notifications">
                 Notifications
-                <% if (notificationCount != null && notificationCount > 0) { %>
-                  <span class="loud font-xsmall" style="background-color: #df3034;padding: 0 5px;color: white;">
-                    (<%= notificationCount %> new)
-                  </span>
-                <% } %>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
This call was used to write a `Notifications (5 new)`  tab title, removing it and having `Notifications` will speed up page load with minimal loss of functionality.