### PR TITLE
PAT-2018 Tune kubernetes autoscaler to avoid alerts in prod

### DIFF
--- a/helm_deploy/check-my-diary/values.yaml
+++ b/helm_deploy/check-my-diary/values.yaml
@@ -49,6 +49,10 @@ generic-service:
                     - "check-my-diary"
             topologyKey: kubernetes.io/hostname
 
+  resources:
+    requests:
+      cpu: 20m
+
   # Environment variables to load into the deployment
   env:
     NODE_ENV: "production"


### PR DESCRIPTION
The pods are maxing out at 4 in prod when they should fall back to 2 when not too busy.
This change ups the threshold for kicking off another pod