### PR TITLE
Added primary navigation

### DIFF
--- a/server/views/pages/calendar.njk
+++ b/server/views/pages/calendar.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {% set pageTitle = applicationName + " - Calendar" %}
+{% set activePrimaryNav = "calendar" %}
 
 {% block beforeContent %}
     {% if fromDPS %}

--- a/server/views/pages/contact-us.njk
+++ b/server/views/pages/contact-us.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Contact us" %}
+{% set activePrimaryNav = "calendar" %}
 
 {% block beforeContent %}
   {{ govukBackLink({ href: "/" }) }}

--- a/server/views/pages/manage-your-notifications.njk
+++ b/server/views/pages/manage-your-notifications.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = applicationName + " - Manage your notifications" %}
+{% set activePrimaryNav = "notifications" %}
 
 {% block beforeContent %}
   {{ govukBackLink({ href: "/", text: "Back to your shift detail" }) }}

--- a/server/views/pages/notification-settings.njk
+++ b/server/views/pages/notification-settings.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Notification settings" %}
+{% set activePrimaryNav = "notifications" %}
 
 {% block beforeContent %}
   {{ govukBackLink({ href: "/notifications/manage" }) }}

--- a/server/views/pages/notifications.njk
+++ b/server/views/pages/notifications.njk
@@ -3,6 +3,7 @@
 {% from "../macros/summary.njk" import summary %}
 
 {% set pageTitle = applicationName + " - Your notifications" %}
+{% set activePrimaryNav = "notifications" %}
 
 {% block beforeContent %}
   {{ govukBackLink({ href: "/", text: "Back to your shift detail" }) }}
@@ -12,7 +13,7 @@
   <main id="main-content" role="main">
     <h1 class="govuk-heading-l">Your notifications</h1>
     <p class="govuk-body">
-      <a href="/notifications/manage" class="govuk-!-padding-left-1">Manage your notifications</a>
+      <a href="/notifications/manage">Manage your notifications</a>
     </p>
 
     <div id="notifications" class="govuk-grid-row">
@@ -33,6 +34,5 @@
         {% endif %}
       </div>
     </div>
-
   </main>
 {% endblock %}

--- a/server/views/pages/pause-notifications.njk
+++ b/server/views/pages/pause-notifications.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% set pageTitle = applicationName + " - How long do you want to pause notifications for?" %}
+{% set activePrimaryNav = "notifications" %}
 
 {% block beforeContent %}
   {{ govukBackLink({ href: "/notifications/manage" }) }}

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -47,9 +47,6 @@
 
         <ul class="moj-header__navigation-list">
           <li class="moj-header__navigation-item">
-            <a class="moj-header__navigation-link" href="/notifications" aria-current="page">Notifications</a>
-          </li>
-          <li class="moj-header__navigation-item">
             <a class="moj-header__navigation-link" href="/account-details" aria-current="page" data-test="logged-in-name">{{ user.displayName | initialiseName }}</a>
           </li>
           <li class="moj-header__navigation-item">

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,4 +1,5 @@
 {% extends "govuk/template.njk" %}
+{%- from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation -%}
 
 {% block head %}
   {% include "./head.njk" %}
@@ -6,8 +7,28 @@
 
 {% block pageTitle %}{{ pageTitle | default(applicationName) }}{% endblock %}
 
+{% set primaryNavItems = [
+  {
+    text: "Calendar",
+    href: "/",
+    active: activePrimaryNav === "calendar"
+  },
+  {
+    text: "Notifications",
+    href: "/notifications",
+    active: activePrimaryNav === "notifications"
+  }
+  ] 
+%}
+
 {% block header %}
   {% include "./header.njk" %}
+  {% if activePrimaryNav %}
+    {{ mojPrimaryNavigation({
+      label: 'Primary navigation',
+      items: primaryNavItems
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block bodyStart %}


### PR DESCRIPTION
This PR moves the "Notifications" link out of the header and moves it to the [primary navigation ](https://design-patterns.service.justice.gov.uk/components/primary-navigation/) MOJ component.

This component renders well on mobile devices and provides easy access to key service features - in this case the "Calendar" and "Notifications".