### PR TITLE
Feedback link update

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -63,12 +63,6 @@
     margin-bottom: 0;
   }
 }
-.feedback-banner {
-  background: $govuk-brand-colour;
-  padding: govuk-spacing(4);
-  max-width: 1170px;
-  margin: 0 auto;
-}
 main {
   @include govuk-responsive-margin(6, "bottom");
 }

--- a/server/views/pages/calendar.njk
+++ b/server/views/pages/calendar.njk
@@ -72,6 +72,8 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-3">Your shift detail</h1>
 
+    <br>
+
     <div class="govuk-grid-row govuk-!-margin-0">
       <div class="strict-grid-column-one-third">
         <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="/calendar/{{previousMonth.link}}" data-qa="previous">

--- a/server/views/pages/manage-your-notifications.njk
+++ b/server/views/pages/manage-your-notifications.njk
@@ -18,7 +18,7 @@
     {% if notificationsEnabled and snoozeUntil %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body govuk-!-margin-bottom-2">You have paused your notifications</p>
+          <p class="govuk-body govuk-!-margin-bottom-2">You have paused your notifications.</p>
           <p class="govuk-body">Notifications will start again on {{ snoozeUntil }}.</p>
 
           <form method="post" action="/notifications/resume" novalidate>
@@ -30,7 +30,7 @@
       {% elif notificationsEnabled %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body">You receive notifications
+          <p class="govuk-body">You receive notifications.
             <a href="/notifications/settings" class="govuk-!-padding-left-1 govuk-link">Change</a>
           </p>
         </div>
@@ -45,7 +45,7 @@
     {% else %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body">You do not receive notifications
+          <p class="govuk-body">You do not receive notifications.
             <a href="/notifications/settings" class="govuk-link">Change</a>
           </p>
         </div>

--- a/server/views/partials/footer.njk
+++ b/server/views/partials/footer.njk
@@ -1,16 +1,12 @@
-<div class="feedback-banner govuk-!-display-none-print" data-test="feedback-banner">
-  <a id="surveyLink"
-     href=""
-     class="govuk-link govuk-link--inverse govuk-!-font-size-16"
-     target="_blank"
-     rel="noopener noreferrer"
-  >Give feedback on this service (opens in a new tab)</a>
-</div>
-<footer class="govuk-footer " role="contentinfo">
-  <div class="govuk-width-container ">
+
+<footer class="govuk-footer" role="contentinfo">
+  <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <ul class="govuk-footer__inline-list">
+          <li class="govuk-footer__inline-list-item">
+            <a id="surveyLink" href="https://www.smartsurvey.co.uk/s/43EWY0/" target="_blank"  class="govuk-footer__link">Feedback (opens in a new tab)</a>
+          </li>
           <li class="govuk-footer__inline-list-item">
             <a id="contactUsLink" href="/contact-us"  class="govuk-footer__link">Contact us</a>
           </li>

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -41,7 +41,6 @@
       <a class="moj-header__link moj-header__link--organisation-name" href="/">HMPPS</a>
 
       <a class="moj-header__link moj-header__link--service-name" href="/">{{ applicationName }}</a>
-    </div>
 
       {% if environmentName %}
           {{ govukTag({
@@ -49,6 +48,8 @@
             classes: environmentNameColour
           }) }}
       {% endif %}
+      
+    </div>
 
     <div class="moj-header__content">
 


### PR DESCRIPTION
This PR moves the feedback link to the footer and removes the feedback banner. The feedback link has also been updated to match the DPS feedback link which replaces the defunct previous link.

This PR also contains minor improvements to wording and UI tweaks that were previously missed. 