### PR TITLE
Fixes feedback link and includes removal of Back links

### DIFF
--- a/server/views/pages/contact-us.njk
+++ b/server/views/pages/contact-us.njk
@@ -1,5 +1,4 @@
 {% extends "../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Contact us" %}
 {% set activePrimaryNav = "calendar" %}

--- a/server/views/pages/contact-us.njk
+++ b/server/views/pages/contact-us.njk
@@ -4,10 +4,6 @@
 {% set pageTitle = applicationName + " - Contact us" %}
 {% set activePrimaryNav = "calendar" %}
 
-{% block beforeContent %}
-  {{ govukBackLink({ href: "/" }) }}
-{% endblock %}
-
 {% block content %}
   <main id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/server/views/pages/manage-your-notifications.njk
+++ b/server/views/pages/manage-your-notifications.njk
@@ -1,5 +1,4 @@
 {% extends "../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = applicationName + " - Manage your notifications" %}

--- a/server/views/pages/manage-your-notifications.njk
+++ b/server/views/pages/manage-your-notifications.njk
@@ -5,10 +5,6 @@
 {% set pageTitle = applicationName + " - Manage your notifications" %}
 {% set activePrimaryNav = "notifications" %}
 
-{% block beforeContent %}
-  {{ govukBackLink({ href: "/", text: "Back to your shift detail" }) }}
-{% endblock %}
-
 {% block content %}
 
   <main id="main-content" role="main">

--- a/server/views/pages/notification-settings.njk
+++ b/server/views/pages/notification-settings.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Notification settings" %}
 {% set activePrimaryNav = "notifications" %}

--- a/server/views/pages/notification-settings.njk
+++ b/server/views/pages/notification-settings.njk
@@ -8,10 +8,6 @@
 {% set pageTitle = applicationName + " - Notification settings" %}
 {% set activePrimaryNav = "notifications" %}
 
-{% block beforeContent %}
-  {{ govukBackLink({ href: "/notifications/manage" }) }}
-{% endblock %}
-
 {% block content %}
   <main id="main-content" role="main">
     <form action="/notifications/settings" method="POST" novalidate>

--- a/server/views/pages/notifications.njk
+++ b/server/views/pages/notifications.njk
@@ -1,5 +1,4 @@
 {% extends "../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../macros/summary.njk" import summary %}
 
 {% set pageTitle = applicationName + " - Your notifications" %}

--- a/server/views/pages/notifications.njk
+++ b/server/views/pages/notifications.njk
@@ -5,10 +5,6 @@
 {% set pageTitle = applicationName + " - Your notifications" %}
 {% set activePrimaryNav = "notifications" %}
 
-{% block beforeContent %}
-  {{ govukBackLink({ href: "/", text: "Back to your shift detail" }) }}
-{% endblock %}
-
 {% block content %}
   <main id="main-content" role="main">
     <h1 class="govuk-heading-l">Your notifications</h1>

--- a/server/views/pages/pause-notifications.njk
+++ b/server/views/pages/pause-notifications.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% set pageTitle = applicationName + " - How long do you want to pause notifications for?" %}

--- a/server/views/pages/pause-notifications.njk
+++ b/server/views/pages/pause-notifications.njk
@@ -8,10 +8,6 @@
 {% set pageTitle = applicationName + " - How long do you want to pause notifications for?" %}
 {% set activePrimaryNav = "notifications" %}
 
-{% block beforeContent %}
-  {{ govukBackLink({ href: "/notifications/manage" }) }}
-{% endblock %}
-
 {% block content %}
   <main id="main-content" role="main">
     <h1 class="govuk-heading-l">How long do you want to pause notifications for?</h1>

--- a/server/views/partials/footer.njk
+++ b/server/views/partials/footer.njk
@@ -26,4 +26,3 @@
     </div>
   </div>
 </footer>
-<script nonce="{{ cspNonce }}">document.getElementById('surveyLink').setAttribute("href", "https://eu.surveymonkey.com/r/GYB8Y9Q?source=" + window.location.hostname + window.location.pathname);</script>


### PR DESCRIPTION
this PR includes a fix to he feedback link that was missed in a previous PR.

It also removes back links from pages in the service - they are largely redundant with the introduction of the new use of [MOJ primary navigation bar](https://design-patterns.service.justice.gov.uk/components/primary-navigation/).