### PR TITLE
Removes email address from contact page - no longer in use

### DIFF
--- a/server/views/pages/contact-us.njk
+++ b/server/views/pages/contact-us.njk
@@ -19,9 +19,6 @@
           For queries about Check my diary, please call the Service Desk on
           <span class="govuk-body" style="white-space: nowrap;" nonce="{{ cspNonce }}">0800 917 5148</span>.
         </p>
-        <p class="govuk-body">
-          Alternatively, you can email us at <a href="mailto:checkmydiary@digital.justice.gov.uk" class="govuk-link">checkmydiary@digital.justice.gov.uk</a>.
-        </p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
The [checkmydiary@digital.justice.gov.uk](mailto:checkmydiary@digital.justice.gov.uk). email address is no longer in use after the move away from Google.